### PR TITLE
Fixes for building Valve Wine/Proton beyond 9.0-3 

### DIFF
--- a/emulators/proton-experimental/distinfo
+++ b/emulators/proton-experimental/distinfo
@@ -1,3 +1,3 @@
 TIMESTAMP = 1726811474
-SHA256 (ValveSoftware-wine-experimental-9.0-20250203-488fb296dda334a1e8555a9dd8f5cbe09be2afe5_GH0.tar.gz) = 609c09d0c2d793c4a1fa11d7dfc4051c66ad9e2c8c5f9dbc71b8cccee8d25447
-SIZE (ValveSoftware-wine-experimental-9.0-20250203-488fb296dda334a1e8555a9dd8f5cbe09be2afe5_GH0.tar.gz) = 49199283
+SHA256 (ValveSoftware-wine-experimental-9.0-20250218-b561e8d5d8a86062ca783296cb28ffe6e2be5938_GH0.tar.gz) = 1bc97e67faad921b49ce731d98ded3b0cb53288e93c159a172b0edf931842a99
+SIZE (ValveSoftware-wine-experimental-9.0-20250218-b561e8d5d8a86062ca783296cb28ffe6e2be5938_GH0.tar.gz) = 49527366

--- a/emulators/proton-experimental/files/patch-dlls_d3dx11__42_Makefile.in
+++ b/emulators/proton-experimental/files/patch-dlls_d3dx11__42_Makefile.in
@@ -1,0 +1,11 @@
+--- dlls/d3dx11_42/Makefile.in.orig	2025-02-12 15:34:54.000000000 -0800
++++ dlls/d3dx11_42/Makefile.in	2025-03-04 16:09:37.045469000 -0800
+@@ -1,7 +1,7 @@
+ EXTRADEFS = -DD3DX11_SDK_VERSION=42
+ MODULE    = d3dx11_42.dll
+ IMPORTLIB = d3dx11_42
+-IMPORTS = d3dcompiler d3dx11_43
++IMPORTS = d3dcompiler d3dx11
+ 
+ EXTRADLLFLAGS = -Wb,--prefer-native
+ 


### PR DESCRIPTION
A patch file and distfile change to fix building Valve Wine Experimental. Should also enable compiling 9.0-4 and Experimental Bleeding-Edge as well.